### PR TITLE
Core/PvP - fix crashing when neutral pandas are in world pvp locations

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -69,17 +69,25 @@ Battlefield::~Battlefield()
 // Called when a player enters the zone
 void Battlefield::HandlePlayerEnterZone(Player* player, uint32 /*zone*/)
 {
+    // Neutral players (e.g., Pandaren who haven't chosen a faction) cannot participate in battlefield
+    TeamId teamId = player->GetTeamId();
+    if (teamId == TEAM_NEUTRAL)
+    {
+        OnPlayerEnterZone(player);
+        return;
+    }
+
     // If battle is started,
     // If not full of players > invite player to join the war
     // If full of players > announce to player that BF is full and kick him after a few second if he desn't leave
     if (IsWarTime())
     {
-        if (m_PlayersInWar[player->GetTeamId()].size() + m_InvitedPlayers[player->GetTeamId()].size() < m_MaxPlayer) // Vacant spaces
+        if (m_PlayersInWar[teamId].size() + m_InvitedPlayers[teamId].size() < m_MaxPlayer) // Vacant spaces
             InvitePlayerToWar(player);
         else // No more vacant places
         {
             /// @todo Send a packet to announce it to player
-            m_PlayersWillBeKick[player->GetTeamId()][player->GetGUID()] = GameTime::GetGameTime() + 10;
+            m_PlayersWillBeKick[teamId][player->GetGUID()] = GameTime::GetGameTime() + 10;
             InvitePlayerToQueue(player);
         }
     }
@@ -91,19 +99,22 @@ void Battlefield::HandlePlayerEnterZone(Player* player, uint32 /*zone*/)
     }
 
     // Add player in the list of player in zone
-    m_players[player->GetTeamId()].insert(player->GetGUID());
+    m_players[teamId].insert(player->GetGUID());
     OnPlayerEnterZone(player);
 }
 
 // Called when a player leave the zone
 void Battlefield::HandlePlayerLeaveZone(Player* player, uint32 /*zone*/)
 {
+    // Neutral players (e.g., Pandaren who haven't chosen a faction) are not tracked in battlefield
+    TeamId teamId = player->GetTeamId();
+
     if (IsWarTime())
     {
         // If the player is participating to the battle
-        if (m_PlayersInWar[player->GetTeamId()].find(player->GetGUID()) != m_PlayersInWar[player->GetTeamId()].end())
+        if (teamId != TEAM_NEUTRAL && m_PlayersInWar[teamId].find(player->GetGUID()) != m_PlayersInWar[teamId].end())
         {
-            m_PlayersInWar[player->GetTeamId()].erase(player->GetGUID());
+            m_PlayersInWar[teamId].erase(player->GetGUID());
             if (Group* group = player->GetGroup()) // Remove the player from the raid group
                 group->RemoveMember(player->GetGUID());
 
@@ -111,9 +122,12 @@ void Battlefield::HandlePlayerLeaveZone(Player* player, uint32 /*zone*/)
         }
     }
 
-    m_InvitedPlayers[player->GetTeamId()].erase(player->GetGUID());
-    m_PlayersWillBeKick[player->GetTeamId()].erase(player->GetGUID());
-    m_players[player->GetTeamId()].erase(player->GetGUID());
+    if (teamId != TEAM_NEUTRAL)
+    {
+        m_InvitedPlayers[teamId].erase(player->GetGUID());
+        m_PlayersWillBeKick[teamId].erase(player->GetGUID());
+        m_players[teamId].erase(player->GetGUID());
+    }
     SendRemoveWorldStates(player);
     OnPlayerLeaveZone(player);
 }
@@ -183,10 +197,15 @@ void Battlefield::InvitePlayersInZoneToQueue()
 
 void Battlefield::InvitePlayerToQueue(Player* player)
 {
-    if (m_PlayersInQueue[player->GetTeamId()].count(player->GetGUID()))
+    // Neutral players cannot participate in battlefield
+    TeamId teamId = player->GetTeamId();
+    if (teamId == TEAM_NEUTRAL)
         return;
 
-    if (m_PlayersInQueue[player->GetTeamId()].size() <= m_MinPlayer || m_PlayersInQueue[GetOtherTeam(player->GetTeamId())].size() >= m_MinPlayer)
+    if (m_PlayersInQueue[teamId].count(player->GetGUID()))
+        return;
+
+    if (m_PlayersInQueue[teamId].size() <= m_MinPlayer || m_PlayersInQueue[GetOtherTeam(teamId)].size() >= m_MinPlayer)
         PlayerAcceptInviteToQueue(player);
 }
 
@@ -198,7 +217,11 @@ void Battlefield::InvitePlayersInQueueToWar()
         {
             if (Player* player = ObjectAccessor::FindPlayer(*itr))
             {
-                if (m_PlayersInWar[player->GetTeamId()].size() + m_InvitedPlayers[player->GetTeamId()].size() < m_MaxPlayer)
+                TeamId teamId = player->GetTeamId();
+                if (teamId == TEAM_NEUTRAL)
+                    continue;
+
+                if (m_PlayersInWar[teamId].size() + m_InvitedPlayers[teamId].size() < m_MaxPlayer)
                     InvitePlayerToWar(player);
                 else
                 {
@@ -218,12 +241,16 @@ void Battlefield::InvitePlayersInZoneToWar()
         {
             if (Player* player = ObjectAccessor::FindPlayer(*itr))
             {
-                if (m_PlayersInWar[player->GetTeamId()].count(player->GetGUID()) || m_InvitedPlayers[player->GetTeamId()].count(player->GetGUID()))
+                TeamId teamId = player->GetTeamId();
+                if (teamId == TEAM_NEUTRAL)
                     continue;
-                if (m_PlayersInWar[player->GetTeamId()].size() + m_InvitedPlayers[player->GetTeamId()].size() < m_MaxPlayer)
+
+                if (m_PlayersInWar[teamId].count(player->GetGUID()) || m_InvitedPlayers[teamId].count(player->GetGUID()))
+                    continue;
+                if (m_PlayersInWar[teamId].size() + m_InvitedPlayers[teamId].size() < m_MaxPlayer)
                     InvitePlayerToWar(player);
                 else // Battlefield is full of players
-                    m_PlayersWillBeKick[player->GetTeamId()][player->GetGUID()] = GameTime::GetGameTime() + 10;
+                    m_PlayersWillBeKick[teamId][player->GetGUID()] = GameTime::GetGameTime() + 10;
             }
         }
     }
@@ -239,30 +266,35 @@ void Battlefield::InvitePlayerToWar(Player* player)
     if (!player)
         return;
 
+    // Neutral players cannot participate in battlefield
+    TeamId teamId = player->GetTeamId();
+    if (teamId == TEAM_NEUTRAL)
+        return;
+
     /// @todo needed ?
     if (player->IsInFlight())
         return;
 
     if (player->InArena() || player->GetBattleground())
     {
-        m_PlayersInQueue[player->GetTeamId()].erase(player->GetGUID());
+        m_PlayersInQueue[teamId].erase(player->GetGUID());
         return;
     }
 
     // If the player does not match minimal level requirements for the battlefield, kick him
     if (player->GetLevel() < m_MinLevel)
     {
-        if (m_PlayersWillBeKick[player->GetTeamId()].count(player->GetGUID()) == 0)
-            m_PlayersWillBeKick[player->GetTeamId()][player->GetGUID()] = GameTime::GetGameTime() + 10;
+        if (m_PlayersWillBeKick[teamId].count(player->GetGUID()) == 0)
+            m_PlayersWillBeKick[teamId][player->GetGUID()] = GameTime::GetGameTime() + 10;
         return;
     }
 
     // Check if player is not already in war
-    if (m_PlayersInWar[player->GetTeamId()].count(player->GetGUID()) || m_InvitedPlayers[player->GetTeamId()].count(player->GetGUID()))
+    if (m_PlayersInWar[teamId].count(player->GetGUID()) || m_InvitedPlayers[teamId].count(player->GetGUID()))
         return;
 
-    m_PlayersWillBeKick[player->GetTeamId()].erase(player->GetGUID());
-    m_InvitedPlayers[player->GetTeamId()][player->GetGUID()] = GameTime::GetGameTime() + m_TimeForAcceptInvite;
+    m_PlayersWillBeKick[teamId].erase(player->GetGUID());
+    m_InvitedPlayers[teamId][player->GetGUID()] = GameTime::GetGameTime() + m_TimeForAcceptInvite;
     PlayerAcceptInviteToWar(player);
 }
 
@@ -371,21 +403,36 @@ void Battlefield::DoPlaySoundToAll(uint32 soundID)
 
 bool Battlefield::HasPlayer(Player* player) const
 {
-    return m_players[player->GetTeamId()].find(player->GetGUID()) != m_players[player->GetTeamId()].end();
+    // Neutral players are not tracked in battlefield
+    TeamId teamId = player->GetTeamId();
+    if (teamId == TEAM_NEUTRAL)
+        return false;
+
+    return m_players[teamId].find(player->GetGUID()) != m_players[teamId].end();
 }
 
 // Called in Battlefield::InvitePlayerToQueue
 void Battlefield::PlayerAcceptInviteToQueue(Player* player)
 {
+    // Neutral players cannot participate in battlefield
+    TeamId teamId = player->GetTeamId();
+    if (teamId == TEAM_NEUTRAL)
+        return;
+
     // Add player in queue
-    m_PlayersInQueue[player->GetTeamId()].insert(player->GetGUID());
+    m_PlayersInQueue[teamId].insert(player->GetGUID());
 }
 
 // Called in WorldSession::HandleBfExitRequest
 void Battlefield::AskToLeaveQueue(Player* player)
 {
+    // Neutral players are not tracked in battlefield queue
+    TeamId teamId = player->GetTeamId();
+    if (teamId == TEAM_NEUTRAL)
+        return;
+
     // Remove player from queue
-    m_PlayersInQueue[player->GetTeamId()].erase(player->GetGUID());
+    m_PlayersInQueue[teamId].erase(player->GetGUID());
 }
 
 // Called in WorldSession::HandleHearthAndResurrect
@@ -402,10 +449,15 @@ void Battlefield::PlayerAcceptInviteToWar(Player* player)
     if (!IsWarTime())
         return;
 
+    // Neutral players cannot participate in battlefield
+    TeamId teamId = player->GetTeamId();
+    if (teamId == TEAM_NEUTRAL)
+        return;
+
     if (AddOrSetPlayerToCorrectBfGroup(player))
     {
-        m_PlayersInWar[player->GetTeamId()].insert(player->GetGUID());
-        m_InvitedPlayers[player->GetTeamId()].erase(player->GetGUID());
+        m_PlayersInWar[teamId].insert(player->GetGUID());
+        m_InvitedPlayers[teamId].erase(player->GetGUID());
 
         if (player->isAFK())
             player->ToggleAFK();
@@ -519,17 +571,22 @@ bool Battlefield::AddOrSetPlayerToCorrectBfGroup(Player* player)
     if (!player->IsInWorld())
         return false;
 
+    // Neutral players cannot participate in battlefield groups
+    TeamId teamId = player->GetTeamId();
+    if (teamId == TEAM_NEUTRAL)
+        return false;
+
     if (Group* group = player->GetGroup())
         group->RemoveMember(player->GetGUID());
 
-    Group* group = GetFreeBfRaid(player->GetTeamId());
+    Group* group = GetFreeBfRaid(teamId);
     if (!group)
     {
         group = new Group;
         group->SetBattlefieldGroup(this);
         group->Create(player);
         sGroupMgr->AddGroup(group);
-        m_Groups[player->GetTeamId()].insert(group->GetGUID());
+        m_Groups[teamId].insert(group->GetGUID());
     }
     else if (group->IsMember(player->GetGUID()))
     {
@@ -575,11 +632,17 @@ WorldSafeLocsEntry const* Battlefield::GetClosestGraveyard(Player* player)
 {
     BfGraveyard* closestGY = nullptr;
     float maxdist = -1;
+
+    // Neutral players cannot use faction-controlled graveyards in battlefield
+    TeamId teamId = player->GetTeamId();
+    if (teamId == TEAM_NEUTRAL)
+        return nullptr;
+
     for (uint8 i = 0; i < m_GraveyardList.size(); i++)
     {
         if (m_GraveyardList[i])
         {
-            if (m_GraveyardList[i]->GetControlTeamId() != player->GetTeamId())
+            if (m_GraveyardList[i]->GetControlTeamId() != teamId)
                 continue;
 
             float dist = m_GraveyardList[i]->GetDistance(player);

--- a/src/server/game/OutdoorPvP/OutdoorPvP.cpp
+++ b/src/server/game/OutdoorPvP/OutdoorPvP.cpp
@@ -63,7 +63,12 @@ OutdoorPvP::~OutdoorPvP() = default;
 
 void OutdoorPvP::HandlePlayerEnterZone(Player* player, uint32 /*zone*/)
 {
-    m_players[player->GetTeamId()].insert(player->GetGUID());
+    // Neutral players (e.g., Pandaren who haven't chosen a faction) cannot participate in PvP
+    TeamId teamId = player->GetTeamId();
+    if (teamId == TEAM_NEUTRAL)
+        return;
+
+    m_players[teamId].insert(player->GetGUID());
 }
 
 void OutdoorPvP::HandlePlayerLeaveZone(Player* player, uint32 /*zone*/)
@@ -71,7 +76,13 @@ void OutdoorPvP::HandlePlayerLeaveZone(Player* player, uint32 /*zone*/)
     // remove the world state information from the player (we can't keep everyone up to date, so leave out those who are not in the concerning zones)
     if (!player->GetSession()->PlayerLogout())
         SendRemoveWorldStates(player);
-    m_players[player->GetTeamId()].erase(player->GetGUID());
+
+    // Neutral players (e.g., Pandaren who haven't chosen a faction) are not tracked
+    TeamId teamId = player->GetTeamId();
+    if (teamId == TEAM_NEUTRAL)
+        return;
+
+    m_players[teamId].erase(player->GetGUID());
     TC_LOG_DEBUG("outdoorpvp", "Player {} left an outdoorpvp zone", player->GetName());
 }
 
@@ -174,7 +185,12 @@ void OutdoorPvP::RegisterZone(uint32 zoneId)
 
 bool OutdoorPvP::HasPlayer(Player const* player) const
 {
-    GuidSet const& plSet = m_players[player->GetTeamId()];
+    // Neutral players (e.g., Pandaren who haven't chosen a faction) are not tracked in PvP zones
+    TeamId teamId = player->GetTeamId();
+    if (teamId == TEAM_NEUTRAL)
+        return false;
+
+    GuidSet const& plSet = m_players[teamId];
     return plSet.find(player->GetGUID()) != plSet.end();
 }
 


### PR DESCRIPTION
Core/PvP - fix crashing when neutral pandas are in world pvp locations