### PR TITLE
Phase 3: Recognise account bank tab bags as bag containers

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -9683,7 +9683,8 @@ Bag* Player::GetBagByPos(uint8 bag) const
 {
     if ((bag >= INVENTORY_SLOT_BAG_START && bag < INVENTORY_SLOT_BAG_END)
         || (bag >= BANK_SLOT_BAG_START && bag < BANK_SLOT_BAG_END)
-        || (bag >= REAGENT_BAG_SLOT_START && bag < REAGENT_BAG_SLOT_END))
+        || (bag >= REAGENT_BAG_SLOT_START && bag < REAGENT_BAG_SLOT_END)
+        || (bag >= ACCOUNT_BANK_SLOT_BAG_START && bag < ACCOUNT_BANK_SLOT_BAG_END))
         if (Item* item = GetItemByPos(INVENTORY_SLOT_BAG_0, bag))
             return item->ToBag();
     return nullptr;
@@ -21380,9 +21381,12 @@ void Player::_SaveInventory(CharacterDatabaseTransaction trans)
             }
         }
 
-        // Account bank items are saved separately in _SaveAccountBankItems — skip inventory position save
-        bool isAccountBankItem = IsAccountBankPos(item->GetBagSlot(), item->GetSlot())
-            || (container && IsAccountBankPos(INVENTORY_SLOT_BAG_0, container->GetSlot()));
+        // Items stored INSIDE an account bank tab bag are persisted per-Bnet in
+        // _SaveAccountBankItems, so skip the per-character inventory position write
+        // for them. The tab bag itself (sitting in INVENTORY_SLOT_BAG_0 at slots
+        // ACCOUNT_BANK_SLOT_BAG_START..END) is per-character and MUST go through
+        // the normal character_inventory save path so it can be restored on relog.
+        bool isAccountBankItem = container && IsAccountBankPos(INVENTORY_SLOT_BAG_0, container->GetSlot());
 
         switch (item->GetState())
         {


### PR DESCRIPTION
Two tightly related bugs surfaced after the bank UI was unblocked:

  1. Depositing into a freshly bought tab failed with "bank is full" and "item doesn't go in that slot". Player::CanStoreItem_InBag does its bag lookup through GetBagByPos, which only accepted the three legacy bag-slot ranges (regular inventory, character bank, reagent bag). Slots ACCOUNT_BANK_SLOT_BAG_START..END (100..104) fell through and returned nullptr even after EquipNewItem had placed an ITEM_ACCOUNT_BANK_TAB_BAG into m_items[100], so the storage check rejected every slot. Add the new range.

  2. Tabs disappeared after relog. _SaveInventory's account-bank guard was checking IsAccountBankPos(item->GetBagSlot(), item->GetSlot()), which is true both for items inside a tab bag (bag>=100) AND for the tab bag itself (bag=INVENTORY_SLOT_BAG_0, slot>=100). The bag position never reached character_inventory, so the bag wasn't restored on the next login and the slots vanished. Narrow the guard to the "container is an account bank tab bag" case so the bag itself is persisted normally and only its account-shared contents skip the per-character path.
