### PR TITLE
Phase 3: Implement bank auto-deposit with tab-based item routing

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -9634,6 +9634,103 @@ std::vector<Item*> Player::GetWarboundItemsToDeposit()
     return itemList;
 }
 
+BagSlotFlags Player::GetItemAutoDepositCategory(Item const* item)
+{
+    ItemTemplate const* proto = item->GetTemplate();
+    if (!proto)
+        return BagSlotFlags::None;
+
+    // Junk takes precedence (ITEM_QUALITY_POOR is grey items the user wants to vendor)
+    if (proto->GetQuality() == ITEM_QUALITY_POOR)
+        return BagSlotFlags::PriorityJunk;
+
+    // Crafting reagents (items flagged USED_IN_A_TRADESKILL) get their own bin
+    if (proto->IsCraftingReagent())
+        return BagSlotFlags::PriorityReagents;
+
+    switch (proto->GetClass())
+    {
+        case ITEM_CLASS_WEAPON:
+        case ITEM_CLASS_ARMOR:
+            return BagSlotFlags::PriorityEquipment;
+        case ITEM_CLASS_CONSUMABLE:
+            return BagSlotFlags::PriorityConsumables;
+        case ITEM_CLASS_TRADE_GOODS:
+            return BagSlotFlags::PriorityTradeGoods;
+        case ITEM_CLASS_QUEST:
+            return BagSlotFlags::PriorityQuestItems;
+        default:
+            return BagSlotFlags::None;
+    }
+}
+
+int8 Player::PickAutoDepositTab(::BankType bank, Item const* item) const
+{
+    static constexpr BagSlotFlags AllPriorityFlags =
+        BagSlotFlags::PriorityEquipment   | BagSlotFlags::PriorityConsumables |
+        BagSlotFlags::PriorityTradeGoods  | BagSlotFlags::PriorityJunk        |
+        BagSlotFlags::PriorityQuestItems  | BagSlotFlags::PriorityReagents;
+
+    BagSlotFlags itemCategory = GetItemAutoDepositCategory(item);
+
+    auto pick = [&](auto const& tabs) -> int8
+    {
+        int8 fallback = -1;
+        for (std::size_t i = 0; i < tabs.size(); ++i)
+        {
+            BagSlotFlags flags = static_cast<BagSlotFlags>(int32(*tabs[i].DepositFlags));
+
+            // "Cleanup: Ignore this tab" — opt out of auto-deposit entirely
+            if ((flags & BagSlotFlags::DisableAutoSort) != BagSlotFlags::None)
+                continue;
+
+            // First match on the item's specific category wins
+            if (itemCategory != BagSlotFlags::None && (flags & itemCategory) != BagSlotFlags::None)
+                return int8(i);
+
+            // Remember the first tab with no priority filters as a generic fallback
+            if (fallback < 0 && (flags & AllPriorityFlags) == BagSlotFlags::None)
+                fallback = int8(i);
+        }
+        return fallback;
+    };
+
+    return (bank == ::BankType::Account)
+        ? pick(m_activePlayerData->AccountBankTabSettings)
+        : pick(m_activePlayerData->CharacterBankTabSettings);
+}
+
+std::vector<Item*> Player::GetItemsForBankAutoDeposit(::BankType bank, bool includeReagents) const
+{
+    std::vector<Item*> itemList;
+    ForEachItem(ItemSearchLocation::Inventory, [&itemList, bank, includeReagents](Item* item)
+    {
+        ItemTemplate const* proto = item->GetTemplate();
+        if (!proto)
+            return ItemSearchCallbackResult::Continue;
+
+        // Quest items and non-empty bags never auto-deposit
+        if (proto->GetClass() == ITEM_CLASS_QUEST || item->IsNotEmptyBag())
+            return ItemSearchCallbackResult::Continue;
+
+        if (bank == ::BankType::Account)
+        {
+            // Account bank rejects character-soulbound items (only warbound / BoA / unbound allowed)
+            if (item->IsSoulBound() && !item->IsAccountBound())
+                return ItemSearchCallbackResult::Continue;
+
+            // The "Include tradeable reagents" checkbox in the warband bank UI
+            if (!includeReagents && proto->IsCraftingReagent())
+                return ItemSearchCallbackResult::Continue;
+        }
+
+        itemList.push_back(item);
+        return ItemSearchCallbackResult::Continue;
+    });
+
+    return itemList;
+}
+
 Item* Player::GetItemByGuid(ObjectGuid guid) const
 {
     Item* result = nullptr;

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1492,6 +1492,9 @@ class TC_GAME_API Player final : public Unit, public GridObject<Player>
         Bag*  GetBagByPos(uint8 slot) const;
         std::vector<Item*> GetCraftingReagentItemsToDeposit();
         std::vector<Item*> GetWarboundItemsToDeposit();
+        std::vector<Item*> GetItemsForBankAutoDeposit(::BankType bank, bool includeReagents) const;
+        static BagSlotFlags GetItemAutoDepositCategory(Item const* item);
+        int8 PickAutoDepositTab(::BankType bank, Item const* item) const;
         Item* GetWeaponForAttack(WeaponAttackType attackType, bool useable = false) const;
         Item* GetShield(bool useable = false) const;
         Item* GetChildItemByGuid(ObjectGuid guid) const;

--- a/src/server/game/Handlers/BankHandler.cpp
+++ b/src/server/game/Handlers/BankHandler.cpp
@@ -287,42 +287,68 @@ void WorldSession::HandleUpdateBankTabSettings(WorldPackets::Bank::UpdateBankTab
     }
 }
 
+// Try every tab in the bank starting with the priority pick, falling back to any tab
+// without DisableAutoSort. Returns true if the item was deposited.
+static bool TryAutoDepositItem(Player* player, BankType bank, Item* item)
+{
+    uint8 const bagStart = (bank == BankType::Account) ? ACCOUNT_BANK_SLOT_BAG_START : BANK_SLOT_BAG_START;
+    uint8 const tabCount = (bank == BankType::Account) ? player->GetAccountBankTabCount() : player->GetCharacterBankTabCount();
+    if (!tabCount)
+        return false;
+
+    auto attemptStore = [&](uint8 bag) -> bool
+    {
+        ItemPosCountVec dest;
+        InventoryResult msg = (bank == BankType::Account)
+            ? player->CanAccountBankItem(bag, NULL_SLOT, dest, item, false)
+            : player->CanBankItem(bag, NULL_SLOT, dest, item, false);
+        if (msg != EQUIP_ERR_OK)
+            return false;
+
+        if (dest.size() == 1 && dest[0].pos == item->GetPos())
+            return false;
+
+        player->RemoveItem(item->GetBagSlot(), item->GetSlot(), true);
+        player->BankItem(dest, item, true);
+        return true;
+    };
+
+    // First, try the tab whose DepositFlags match the item's category.
+    if (int8 preferred = player->PickAutoDepositTab(bank, item); preferred >= 0)
+        if (attemptStore(bagStart + uint8(preferred)))
+            return true;
+
+    // Fall back to scanning all other tabs in order.
+    for (uint8 i = 0; i < tabCount; ++i)
+        if (attemptStore(bagStart + i))
+            return true;
+
+    return false;
+}
+
 void WorldSession::HandleAutoDepositCharacterBank(WorldPackets::Bank::AutoDepositCharacterBank const& autoDepositCharacterBank)
 {
     if (!CanUseBank(autoDepositCharacterBank.Banker))
     {
-        TC_LOG_DEBUG("network", "WORLD: HandleReagentBankDepositOpcode - {} not found or you can't interact with him.", autoDepositCharacterBank.Banker);
+        TC_LOG_DEBUG("network", "WORLD: HandleAutoDepositCharacterBank - {} not found or you can't interact with him.", autoDepositCharacterBank.Banker);
         return;
     }
 
-    if (!_player->IsReagentBankUnlocked())
+    if (_player->GetCharacterBankTabCount() == 0)
     {
-        _player->SendEquipError(EQUIP_ERR_REAGENT_BANK_LOCKED);
+        _player->SendEquipError(EQUIP_ERR_BANK_FULL);
         return;
     }
 
-    // query all reagents from player's inventory
     bool anyDeposited = false;
-    for (Item* item : _player->GetCraftingReagentItemsToDeposit())
+    for (Item* item : _player->GetItemsForBankAutoDeposit(BankType::Character, /*includeReagents*/ true))
     {
-        ItemPosCountVec dest;
-        InventoryResult msg = _player->CanBankItem(NULL_BAG, NULL_SLOT, dest, item, false, true, true);
-        if (msg != EQUIP_ERR_OK)
+        if (!TryAutoDepositItem(_player, BankType::Character, item))
         {
-            if (msg != EQUIP_ERR_REAGENT_BANK_FULL || !anyDeposited)
-                _player->SendEquipError(msg, item, nullptr);
+            if (!anyDeposited)
+                _player->SendEquipError(EQUIP_ERR_BANK_FULL, item, nullptr);
             break;
         }
-
-        if (dest.size() == 1 && dest[0].pos == item->GetPos())
-        {
-            _player->SendEquipError(EQUIP_ERR_CANT_SWAP, item, nullptr);
-            continue;
-        }
-
-        // store reagent
-        _player->RemoveItem(item->GetBagSlot(), item->GetSlot(), true);
-        _player->BankItem(dest, item, true);
         anyDeposited = true;
     }
 }
@@ -341,27 +367,15 @@ void WorldSession::HandleAutoDepositAccountBank(WorldPackets::Bank::AutoDepositA
         return;
     }
 
-    // Deposit all warbound/BoA items from inventory
     bool anyDeposited = false;
-    for (Item* item : _player->GetWarboundItemsToDeposit())
+    for (Item* item : _player->GetItemsForBankAutoDeposit(BankType::Account, autoDepositAccountBank.IncludeReagents))
     {
-        ItemPosCountVec dest;
-        InventoryResult msg = _player->CanAccountBankItem(NULL_BAG, NULL_SLOT, dest, item, false);
-        if (msg != EQUIP_ERR_OK)
+        if (!TryAutoDepositItem(_player, BankType::Account, item))
         {
-            if (msg != EQUIP_ERR_BANK_FULL || !anyDeposited)
-                _player->SendEquipError(msg, item, nullptr);
+            if (!anyDeposited)
+                _player->SendEquipError(EQUIP_ERR_BANK_FULL, item, nullptr);
             break;
         }
-
-        if (dest.size() == 1 && dest[0].pos == item->GetPos())
-        {
-            _player->SendEquipError(EQUIP_ERR_CANT_SWAP, item, nullptr);
-            continue;
-        }
-
-        _player->RemoveItem(item->GetBagSlot(), item->GetSlot(), true);
-        _player->BankItem(dest, item, true);
         anyDeposited = true;
     }
 }

--- a/src/server/game/Server/Packets/BankPackets.cpp
+++ b/src/server/game/Server/Packets/BankPackets.cpp
@@ -48,6 +48,10 @@ void AutoDepositCharacterBank::Read()
 
 void AutoDepositAccountBank::Read()
 {
+    // Wire layout (verified against build 12.0.5.67186 client serializer):
+    //   1 bit  - IncludeReagents (CVar bankAutoDepositReagents)
+    //   GUID   - Banker
+    _worldPacket >> Bits<1>(IncludeReagents);
     _worldPacket >> Banker;
 }
 

--- a/src/server/game/Server/Packets/BankPackets.h
+++ b/src/server/game/Server/Packets/BankPackets.h
@@ -83,6 +83,7 @@ namespace WorldPackets
             void Read() override;
 
             ObjectGuid Banker;
+            bool IncludeReagents = false;
         };
 
         class AccountBankDepositMoney final : public ClientPacket


### PR DESCRIPTION
Replace the narrow reagent-only / warbound-only auto-deposit handlers with the modern "Deposit All" behaviour the warband bank UI expects:

  - Each tab's BagSlotFlags::Priority<Equipment|Consumables|TradeGoods| Junk|QuestItems|Reagents> are persisted in {character,account}_bank_ tab_settings.depositFlags. The handler now classifies every eligible inventory item (Player::GetItemAutoDepositCategory) and routes it to the first tab whose flags match (Player::PickAutoDepositTab), falling back to the first tab without any priority filter, then to any tab without DisableAutoSort ("Cleanup: Ignore this tab").
  - Player::GetItemsForBankAutoDeposit collects eligible inventory items per bank type, applying the warband bank's "Include tradeable reagents" toggle (CVar bankAutoDepositReagents) when bank == Account.

CMSG_AUTO_DEPOSIT_ACCOUNT_BANK actually carries that toggle on the wire (verified against build 12.0.5.67186 client serializer): 1 bit IncludeReagents, then the banker GUID. The previous Read() consumed the GUID byte-aligned and silently mis-parsed when the bit was set. Add the IncludeReagents field and read it first.
