### PR TITLE
Warband/phase3 bank

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -11378,11 +11378,21 @@ InventoryResult Player::CanAccountBankItem(uint8 bag, uint8 slot, ItemPosCountVe
         if (bag >= ACCOUNT_BANK_SLOT_BAG_START && bag < ACCOUNT_BANK_SLOT_BAG_END)
         {
             // Account bank tab bags are generic ITEM_SUBCLASS_CONTAINER bags, so
-            // both passes must run with non_specialized=true (matching CanBankItem).
-            InventoryResult res = CanStoreItem_InBag(bag, dest, pProto, count, true, true, pItem, NULL_BAG, NULL_SLOT);
-            if (res != EQUIP_ERR_OK)
-                res = CanStoreItem_InBag(bag, dest, pProto, count, false, true, pItem, NULL_BAG, NULL_SLOT);
+            // both passes run with non_specialized=true (matching CanBankItem).
+            // First merge with existing stacks (only meaningful for stackables).
+            if (pProto->GetMaxStackSize() != 1)
+            {
+                InventoryResult res = CanStoreItem_InBag(bag, dest, pProto, count, true, true, pItem, NULL_BAG, NULL_SLOT);
+                if (res != EQUIP_ERR_OK)
+                    return res;
 
+                if (count == 0)
+                    return EQUIP_ERR_OK;
+            }
+
+            // Then try empty slots — this must run even when the merge pass returned
+            // EQUIP_ERR_OK without fully placing the stack (no matching stacks found).
+            InventoryResult res = CanStoreItem_InBag(bag, dest, pProto, count, false, true, pItem, NULL_BAG, NULL_SLOT);
             if (res != EQUIP_ERR_OK)
                 return res;
 

--- a/src/server/game/Handlers/BankHandler.cpp
+++ b/src/server/game/Handlers/BankHandler.cpp
@@ -340,8 +340,13 @@ void WorldSession::HandleAutoDepositCharacterBank(WorldPackets::Bank::AutoDeposi
         return;
     }
 
+    // Character bank's "Deposit All" button is labelled "Deposit All Reagents"
+    // (GlobalStrings.CHARACTER_BANK_DEPOSIT_BUTTON_LABEL) and only deposits items
+    // flagged as crafting reagents. The tab-routing below still applies — reagents
+    // go to whichever tab has BagSlotFlags::PriorityReagents set, falling back to
+    // any non-disabled tab.
     bool anyDeposited = false;
-    for (Item* item : _player->GetItemsForBankAutoDeposit(BankType::Character, /*includeReagents*/ true))
+    for (Item* item : _player->GetCraftingReagentItemsToDeposit())
     {
         if (!TryAutoDepositItem(_player, BankType::Character, item))
         {


### PR DESCRIPTION
Replace the narrow reagent-only / warbound-only auto-deposit handlers with the modern "Deposit All" behaviour the warband bank UI expects:

  - Each tab's BagSlotFlags::Priority<Equipment|Consumables|TradeGoods| Junk|QuestItems|Reagents> are persisted in {character,account}_bank_ tab_settings.depositFlags. The handler now classifies every eligible inventory item (Player::GetItemAutoDepositCategory) and routes it to the first tab whose flags match (Player::PickAutoDepositTab), falling back to the first tab without any priority filter, then to any tab without DisableAutoSort ("Cleanup: Ignore this tab").
  - Player::GetItemsForBankAutoDeposit collects eligible inventory items per bank type, applying the warband bank's "Include tradeable reagents" toggle (CVar bankAutoDepositReagents) when bank == Account.

CMSG_AUTO_DEPOSIT_ACCOUNT_BANK actually carries that toggle on the wire (verified against build 12.0.5.67186 client serializer): 1 bit IncludeReagents, then the banker GUID. The previous Read() consumed the GUID byte-aligned and silently mis-parsed when the bit was set. Add the IncludeReagents field and read it first.
